### PR TITLE
remove bash dependency, use $SHELL with and without xterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ which can be linked or even preloaded to system to catch signals
 and automatically run gdb (or, in future, any other debugger).
 
 The project is BSD-licensed. It has no fancy dependencies,
-just Glibc, Bash and GDB.
+just Glibc and GDB.
 
 # Usage
 
@@ -33,7 +33,9 @@ Available runtime options:
 * handle\_signals - attach debugger on all bad signals
   (SIGSEGV, SIGILL, etc.)
 * debug - print diagnostic info
-* debug\_opts - additional options to pass to debugger
+* debug\_opts - additional options to pass to debugger.
+  Note: the debugger command line, including those options is
+  interpreted by $SHELL (typically your login shell).
 
 # Future plans
 

--- a/src/gdb.c
+++ b/src/gdb.c
@@ -65,12 +65,18 @@ int run_gdb(unsigned dbg_flags, const char *dbg_opts) {
       }
 
       if(dbg_flags & DEBUGME_XTERM) {
+	// xterm will run $SHELL to interpret that command line
+	// It's the user's responsibility to ensure the dbg_opts
+	// use the right syntax for that shell.
         execl("/usr/bin/xterm", "/usr/bin/xterm", "-e", buf, (char *)0);
       } else {
-        execl("/bin/bash", "/bin/bash", "-c", buf, (char *)0);
+	char *shell = getenv("SHELL");
+	if (!shell) shell = "/bin/sh";
+
+        execl(shell, shell, "-c", buf, (char *)0);
       }
 
-      SAFE_MSG("libdebugme: failed to run gdb command: /bin/bash -c ");
+      SAFE_MSG("libdebugme: failed to run gdb command: ");
       SAFE_MSG(buf);
       SAFE_MSG("\n");
       _exit(1);


### PR DESCRIPTION
Note that when running through xterm, it's the user's $SHELL that will be used to parse the command line, so you might as well use that as well when not using xterm and remove the bash dependency.