### PR TITLE
Fix build on recent glibc

### DIFF
--- a/src/debugme.c
+++ b/src/debugme.c
@@ -46,7 +46,7 @@ EXPORT int debugme_install_sighandlers(unsigned dbg_flags_, const char *dbg_opts
   size_t i;
   for(i = 0; i < ARRAY_SIZE(bad_signals); ++i) {
     int sig = bad_signals[i];
-    const char *signame = sys_siglist[sig];
+    const char *signame = strsignal(sig);
     if(debug) {
       fprintf(stderr, "debugme: setting signal handler for signal %d (%s)\n", sig, signame);
     }


### PR DESCRIPTION
This PR removes the usage of the sys_siglist, which was removed in glibc 2.32, causing this project to fail to build on recent Linux distros.

I based my approach off [an existing project's bugfix](https://github.com/greenbone/gvmd/pull/1280) (replace `sys_siglist[sig]` with `strsignal(sig)`). The documentation for the removal of `sys_siglist` is in the [glibc 2.32 release notes](https://sourceware.org/pipermail/libc-announce/2020/000029.html) (2020-08).

The usage of sys_siglist in this program is *very* minimal, so in-depth analysis is probably overkill. But I looked deeper anyway...

Looking at the [glibc 2.32 release notes](https://sourceware.org/pipermail/libc-announce/2020/000029.html), it appears there are multiple functions returning different types of names, but `strsignal` is good enough for this case.

Looking at the [strsignal manpage](https://man7.org/linux/man-pages/man3/strsignal.3.html)... *sigh* it's not thread-safe, and the return value may be null for unrecognized signals on OSes other than Linux. It doesn't matter in this case though, since we're on Linux and hopefully all signals are recognized.

I found a [source](https://www.postgresql.org/message-id/32357.1545065523%40sss.pgh.pa.us) saying that there are no known OSes with sys_siglist but not strsignal, so this change should not reduce compatibility with any versions of Linux.

(I was unable to make debugme actually work on Arch Linux though. gdb never triggered when an app segfaulted. Perhaps drkonqi is interfering?)

Fixes #3.